### PR TITLE
Include unzip

### DIFF
--- a/Ubuntu18.04-OpenCATS-Install.sh
+++ b/Ubuntu18.04-OpenCATS-Install.sh
@@ -8,7 +8,7 @@ apt update
 add-apt-repository -y ppa:ondrej/php
 apt update
 apt upgrade -y
-apt install -y mariadb-server mariadb-client apache2 php5.6 php5.6-soap php5.6-ldap php5.6-mysql php5.6-gd php5.6-xml php5.6-curl php5.6-mbstring php5.6-zip antiword poppler-utils html2text unrtf
+apt install -y mariadb-server mariadb-client apache2 php5.6 php5.6-soap php5.6-ldap php5.6-mysql php5.6-gd php5.6-xml php5.6-curl php5.6-mbstring php5.6-zip antiword poppler-utils html2text unrtf unzip
 
 # Set up database
 mysql -u root --execute="CREATE DATABASE cats_dev;"


### PR DESCRIPTION
Unzip is not included as a default tool in a digital ocean Ubuntu 18.04 droplet.